### PR TITLE
Add support for tox (http://tox.testrun.org/) and Travis CI (http://travis-ci.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build
 .eprj
 *.pyc
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+python:
+  - 2.6
+  - 2.7
+  - pypy
+
+before_install: pip install --use-mirrors nose PyYAML
+
+install: python setup.py install
+
+script: nosetests tests/units

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, pypy
+
+[testenv]
+commands =
+    nosetests tests/units
+deps =
+    nose
+    PyYAML


### PR DESCRIPTION
Sample Travis CI build for my fork: http://travis-ci.org/#!/msabramo/freshen/builds/1764231

To set up Travis CI for your own repo, see http://about.travis-ci.org/docs/user/getting-started/

Sample tox output:

```
~/dev/git-repos/freshen$ tox
GLOB sdist-make: /Users/marca/dev/git-repos/freshen/setup.py
py26 sdist-reinst: /Users/marca/dev/git-repos/freshen/.tox/dist/freshen-0.2.zip
py26 runtests: commands[0]
.....................
----------------------------------------------------------------------
Ran 21 tests in 3.744s

OK
py27 sdist-reinst: /Users/marca/dev/git-repos/freshen/.tox/dist/freshen-0.2.zip
py27 runtests: commands[0]
.....................
----------------------------------------------------------------------
Ran 21 tests in 3.650s

OK
pypy sdist-reinst: /Users/marca/dev/git-repos/freshen/.tox/dist/freshen-0.2.zip
pypy runtests: commands[0]
.....................
----------------------------------------------------------------------
Ran 21 tests in 3.147s

OK
_________________________________________________________________________ summary __________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  congratulations :)
```